### PR TITLE
Layout improvements

### DIFF
--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 
 export default function Footer() {
     return (
-        <footer className="bg-white rounded-lg shadow m-4 dark:bg-gray-800">
+        <footer className="bg-white rounded-lg shadow dark:bg-gray-800">
             <div className="w-full mx-auto max-w-screen-xl p-4 md:flex md:items-center md:justify-between">
                 <span className="text-sm text-gray-500 sm:text-center dark:text-gray-400">
                     © 2023 Made by

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 export default function Footer() {
     return (
         <footer className="bg-white rounded-lg shadow dark:bg-gray-800">
-            <div className="w-full mx-auto max-w-screen-xl p-4 md:flex md:items-center md:justify-between">
+            <div className="w-full mx-auto container p-4 md:flex md:items-center md:justify-between">
                 <span className="text-sm text-gray-500 sm:text-center dark:text-gray-400">
                     © 2023 Made by
                     <a

--- a/src/components/navbar.jsx
+++ b/src/components/navbar.jsx
@@ -16,7 +16,7 @@ export default function Navbar() {
         <Disclosure as="nav" className="bg-gray-800 rounded-md">
             {({ open }) => (
                 <>
-                    <div className="mx-auto max-w-7xl px-2 sm:px-6 lg:px-8">
+                    <div className="mx-auto container px-2 sm:px-6 lg:px-8">
                         <div className="relative flex h-16 items-center justify-between">
                             <div className="absolute inset-y-0 left-0 flex items-center sm:hidden">
                                 {/* Mobile menu button*/}

--- a/src/index.css
+++ b/src/index.css
@@ -7,7 +7,6 @@
     line-height: 1.5;
     font-weight: 400;
 
-    color-scheme: light dark;
     color: rgba(255, 255, 255, 0.87);
     background-color: #242424;
 
@@ -16,65 +15,4 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     -webkit-text-size-adjust: 100%;
-}
-
-#root {
-    max-width: 1280px;
-    margin: 0 auto;
-    padding: 2rem;
-    text-align: center;
-}
-
-a {
-    font-weight: 500;
-    color: #646cff;
-    text-decoration: inherit;
-}
-a:hover {
-    color: #535bf2;
-}
-
-body {
-    margin: 0;
-    display: flex;
-    place-items: center;
-    min-width: 320px;
-    min-height: 100vh;
-}
-
-h1 {
-    font-size: 3.2em;
-    line-height: 1.1;
-}
-
-button {
-    border-radius: 8px;
-    border: 1px solid transparent;
-    padding: 0.6em 1.2em;
-    font-size: 1em;
-    font-weight: 500;
-    font-family: inherit;
-    background-color: #1a1a1a;
-    cursor: pointer;
-    transition: border-color 0.25s;
-}
-button:hover {
-    border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-    outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-    :root {
-        color: #213547;
-        background-color: #ffffff;
-    }
-    a:hover {
-        color: #747bff;
-    }
-    button {
-        background-color: #f9f9f9;
-    }
 }

--- a/src/layouts/layout.jsx
+++ b/src/layouts/layout.jsx
@@ -4,10 +4,12 @@ import { Outlet } from 'react-router-dom';
 
 export default function Layout() {
     return (
-        <>
+        <div className="flex flex-col min-h-screen">
             <Navbar />
-            <Outlet />
+            <main className="container mx-auto flex-grow">
+                <Outlet />
+            </main>
             <Footer />
-        </>
+        </div>
     );
 }

--- a/src/layouts/layout.jsx
+++ b/src/layouts/layout.jsx
@@ -1,0 +1,13 @@
+import Navbar from '../components/navbar';
+import Footer from '../components/footer';
+import { Outlet } from 'react-router-dom';
+
+export default function Layout() {
+    return (
+        <>
+            <Navbar />
+            <Outlet />
+            <Footer />
+        </>
+    );
+}

--- a/src/layouts/layout.jsx
+++ b/src/layouts/layout.jsx
@@ -6,7 +6,7 @@ export default function Layout() {
     return (
         <div className="flex flex-col min-h-screen">
             <Navbar />
-            <main className="container mx-auto flex-grow">
+            <main className="container mx-auto p-4 md:p-6 flex-grow">
                 <Outlet />
             </main>
             <Footer />

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,18 +1,25 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
-import Root from './routes/root';
-import Pokemon from './routes/pokemon-list.jsx';
+import Layout from './layouts/layout';
+import Pokemon from './routes/pokemon-list';
+import Home from './routes/home';
 import './index.css';
 
 const router = createBrowserRouter([
     {
         path: '/',
-        element: <Root />,
-    },
-    {
-        path: '/pokemon-list',
-        element: <Pokemon />,
+        element: <Layout />,
+        children: [
+            {
+                path: '/',
+                element: <Home />,
+            },
+            {
+                path: '/pokemon-list',
+                element: <Pokemon />,
+            },
+        ],
     },
 ]);
 

--- a/src/routes/home.jsx
+++ b/src/routes/home.jsx
@@ -1,14 +1,10 @@
-import Navbar from '../components/navbar';
-import Footer from '../components/footer';
 import PokedexImage from '../assets/images/pokedex.png';
 
-export default function Root() {
+export default function Home() {
     return (
         <div>
-            <Navbar />
             <h1 className="mt-3 mb-5 font-mono text-5xl font-bold">Pokedex</h1>
             <img src={PokedexImage} alt="" className="rounded-md" />
-            <Footer />
         </div>
     );
 }

--- a/src/routes/home.jsx
+++ b/src/routes/home.jsx
@@ -2,7 +2,7 @@ import PokedexImage from '../assets/images/pokedex.png';
 
 export default function Home() {
     return (
-        <div>
+        <div className="flex flex-col items-center">
             <h1 className="mt-3 mb-5 font-mono text-5xl font-bold">Pokedex</h1>
             <img src={PokedexImage} alt="" className="rounded-md" />
         </div>

--- a/src/routes/pokemon-list.jsx
+++ b/src/routes/pokemon-list.jsx
@@ -1,6 +1,4 @@
 import { useEffect, useState } from 'react';
-import Navbar from '../components/navbar';
-import Footer from '../components/footer';
 
 const POKEMON_TYPE_COLORS = {
     normal: '#a8a77a',
@@ -33,50 +31,46 @@ function Pokemon() {
     }, []);
 
     return (
-        <>
-            <Navbar />
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 ">
-                {pokemon.map((pokemon) => (
-                    <div
-                        key={pokemon.ndex}
-                        className="flex flex-col items-center gap-4 p-4 text-black bg-white rounded-md"
-                    >
-                        <div className="self-start text-lg font-bold">
-                            {pokemon.ndex}
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 ">
+            {pokemon.map((pokemon) => (
+                <div
+                    key={pokemon.ndex}
+                    className="flex flex-col items-center gap-4 p-4 text-black bg-white rounded-md"
+                >
+                    <div className="self-start text-lg font-bold">
+                        {pokemon.ndex}
+                    </div>
+                    <img src={pokemon.imageUrl} alt="" loading="lazy" />
+                    <h2 className="text-3xl font-bold">{pokemon.name}</h2>
+                    <div className="flex gap-4">
+                        <div
+                            className="px-4 py-1 font-bold text-white rounded-md bg-"
+                            style={{
+                                backgroundColor:
+                                    POKEMON_TYPE_COLORS[
+                                        pokemon.type1.toLowerCase()
+                                    ],
+                            }}
+                        >
+                            {pokemon.type1}
                         </div>
-                        <img src={pokemon.imageUrl} alt="" loading="lazy" />
-                        <h2 className="text-3xl font-bold">{pokemon.name}</h2>
-                        <div className="flex gap-4">
+                        {pokemon.type2 && (
                             <div
-                                className="px-4 py-1 font-bold text-white rounded-md bg-"
+                                className="px-4 py-1 font-bold text-white rounded-md"
                                 style={{
                                     backgroundColor:
                                         POKEMON_TYPE_COLORS[
-                                            pokemon.type1.toLowerCase()
+                                            pokemon.type2.toLowerCase()
                                         ],
                                 }}
                             >
-                                {pokemon.type1}
+                                {pokemon.type2}
                             </div>
-                            {pokemon.type2 && (
-                                <div
-                                    className="px-4 py-1 font-bold text-white rounded-md"
-                                    style={{
-                                        backgroundColor:
-                                            POKEMON_TYPE_COLORS[
-                                                pokemon.type2.toLowerCase()
-                                            ],
-                                    }}
-                                >
-                                    {pokemon.type2}
-                                </div>
-                            )}
-                        </div>
+                        )}
                     </div>
-                ))}
-            </div>
-            <Footer />
-        </>
+                </div>
+            ))}
+        </div>
     );
 }
 

--- a/src/routes/root.jsx
+++ b/src/routes/root.jsx
@@ -6,7 +6,7 @@ export default function Root() {
     return (
         <div>
             <Navbar />
-            <h1 className="mt-3 mb-5 font-mono font-bold">Pokedex</h1>
+            <h1 className="mt-3 mb-5 font-mono text-5xl font-bold">Pokedex</h1>
             <img src={PokedexImage} alt="" className="rounded-md" />
             <Footer />
         </div>


### PR DESCRIPTION
Improve the general layout of the app

Changes:
- Remove duplication of shared components (header and footer) - The header and footer component was being used in multiple route components so I instead created a layout component to prevent duplication and make it easier to update layout styles. [see this commit](https://github.com/tanselbay1/pokedex_frontend/pull/5/commits/4af6dea2c396b0da66b0b155b7da70c7b4c7552d)
- Remove footer margin
- Make the footer always be stuck to bottom of page (even if main content is small)
- Add padding to the main content of the page
- Make header and footer span full width (boilerplate css prevented this)