### PR TITLE
Fix light / dark theme styles

### DIFF
--- a/src/components/audioPlayer.jsx
+++ b/src/components/audioPlayer.jsx
@@ -1,42 +1,38 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect } from 'react';
 import { BellIcon } from '@heroicons/react/24/outline';
 
-const useAudio = url => {
-  const [audio] = useState(new Audio(url));
-  const [playing, setPlaying] = useState(false);
+const useAudio = (url) => {
+    const [audio] = useState(new Audio(url));
+    const [playing, setPlaying] = useState(false);
 
-  const toggle = () => setPlaying(!playing);
+    const toggle = () => setPlaying(!playing);
 
-  useEffect(() => {
-      playing ? audio.play() : audio.pause();
-    },
-    [playing]
-  );
+    useEffect(() => {
+        playing ? audio.play() : audio.pause();
+    }, [playing]);
 
-  useEffect(() => {
-    audio.addEventListener('ended', () => setPlaying(false));
-    return () => {
-      audio.removeEventListener('ended', () => setPlaying(false));
-    };
-  }, []);
+    useEffect(() => {
+        audio.addEventListener('ended', () => setPlaying(false));
+        return () => {
+            audio.removeEventListener('ended', () => setPlaying(false));
+        };
+    }, []);
 
-  return [playing, toggle];
+    return [playing, toggle];
 };
 
 const Player = ({ url }) => {
-  const [playing, toggle] = useAudio(url);
+    const [playing, toggle] = useAudio(url);
 
-  return (
-      <button
-         onClick={toggle}
-         type="button"
-         className="rounded-full bg-gray-800 p-1 text-gray-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800"
-      >
-         <BellIcon className="h-6 w-6"
-                  aria-hidden="true"/>
-      </button>
-      
-  );
+    return (
+        <button
+            onClick={toggle}
+            type="button"
+            className="rounded-full bg-gray-800 p-1 text-gray-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800"
+        >
+            <BellIcon className="h-6 w-6" aria-hidden="true" />
+        </button>
+    );
 };
 
 export default Player;

--- a/src/components/audioPlayer.jsx
+++ b/src/components/audioPlayer.jsx
@@ -28,7 +28,7 @@ const Player = ({ url }) => {
         <button
             onClick={toggle}
             type="button"
-            className="rounded-full bg-gray-800 p-1 text-gray-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800"
+            className="rounded-full bg-gray-800 p-1 text-white  focus:outline-none focus:ring-2  dark:focus:ring-white focus:ring-offset-2 dark:focus:ring-offset-0 focus:ring-gray-800"
         >
             <BellIcon className="h-6 w-6" aria-hidden="true" />
         </button>

--- a/src/components/navbar.jsx
+++ b/src/components/navbar.jsx
@@ -11,14 +11,17 @@ const navigation = [
 
 export default function Navbar() {
     return (
-        <Disclosure as="nav" className="bg-gray-800 rounded-md main-nav">
+        <Disclosure
+            as="nav"
+            className="bg-white dark:bg-gray-800 rounded-md main-nav"
+        >
             {({ open }) => (
                 <>
                     <div className="mx-auto container px-2 sm:px-6 lg:px-8">
                         <div className="relative flex h-16 items-center justify-between">
                             <div className="absolute inset-y-0 left-0 flex items-center sm:hidden">
                                 {/* Mobile menu button*/}
-                                <Disclosure.Button className="inline-flex items-center justify-center rounded-md p-2 text-gray-400 hover:bg-gray-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white">
+                                <Disclosure.Button className="inline-flex items-center justify-center rounded-md p-2 text-gray-800 dark:text-white hover:text-white hover:bg-gray-700  focus:outline-none focus:ring-2 focus:ring-inset focus:ring-gray-800 dark:focus:ring-white">
                                     <span className="sr-only">
                                         Open main menu
                                     </span>
@@ -51,7 +54,7 @@ export default function Navbar() {
                                             <NavLink
                                                 key={item.name}
                                                 to={item.href}
-                                                className="rounded-md px-3 py-2 text-sm font-medium text-gray-300 hover:bg-gray-700 hover:text-white"
+                                                className="rounded-md px-3 py-2 text-sm font-medium text-gray-500 dark:text-gray-300 hover:bg-gray-700 hover:text-white"
                                             >
                                                 {item.name}
                                             </NavLink>
@@ -70,7 +73,7 @@ export default function Navbar() {
                                 <NavLink
                                     key={item.name}
                                     to={item.href}
-                                    className="rounded-md px-3 py-2 text-sm font-medium text-gray-300 hover:bg-gray-700 hover:text-white"
+                                    className="rounded-md px-3 py-2 text-sm font-medium text-gray-500 dark:text-gray-300 hover:bg-gray-700 hover:text-white"
                                 >
                                     {item.name}
                                 </NavLink>


### PR DESCRIPTION
# Changes
- Adds light theme colours as a default to the header (to match footer)
- Improves focus ring colouring for mobile button and notifications icon button

# How to test
You can switch between light and dark mode easily using the Chrome Dev Tools rendering options, see image below
![image](https://github.com/tanselbay1/pokedex_frontend/assets/62726177/8f5175b0-6672-49d2-bc98-0e68dbe8fe0a)

Switch between light and dark mode and test the following to make sure UI looks nice. 

1. Try desktop and mobile viewports
2. Try focus state of the different header elements

# Screenshots
## Mobile Default/Light mode
| Before | After |
|--------|--------|
| <img src="https://github.com/tanselbay1/pokedex_frontend/assets/62726177/d608d772-536e-4838-95a8-995f2d803e93" width="400"/>| <img src="https://github.com/tanselbay1/pokedex_frontend/assets/62726177/dca19729-a154-4c68-ad04-00fdd275656b" width="400"/> |