### PR TITLE
Add pokedex UI

### DIFF
--- a/src/components/pokedex.jsx
+++ b/src/components/pokedex.jsx
@@ -1,0 +1,17 @@
+export default function Pokedex() {
+    return (
+        <div className="bg-red-500 w-full p-4 space-y-4 rounded-lg max-w-md">
+            <div className="bg-gray-400 aspect-square max-w-[150px] sm:max-w-[200px] mx-auto"></div>
+            <form className="flex flex-col gap-4">
+                <input className="text-black px-2 py-1" type="text" />
+                <button
+                    className="bg-white px-2 py-1 text-black rounded-md"
+                    type="submit"
+                >
+                    Search
+                </button>
+            </form>
+            <p className="bg-white text-red-700 font-bold px-2 py-1">Error</p>
+        </div>
+    );
+}

--- a/src/routes/home.jsx
+++ b/src/routes/home.jsx
@@ -1,10 +1,10 @@
-import PokedexImage from '../assets/images/pokedex.png';
+import Pokedex from '../components/pokedex';
 
 export default function Home() {
     return (
-        <div className="flex flex-col items-center">
-            <h1 className="mt-3 mb-5 font-mono text-5xl font-bold">Pokedex</h1>
-            <img src={PokedexImage} alt="" className="rounded-md" />
+        <div className="flex flex-col items-center gap-8 mt-8">
+            <h1 className="font-mono text-5xl font-bold">Pokedex</h1>
+            <Pokedex />
         </div>
     );
 }


### PR DESCRIPTION
# Changes
Adds a basic UI without functionality for the Pokedex

# Screenshots
| Mobile | Desktop |
|--------|--------|
|  <img src="https://github.com/tanselbay1/pokedex_frontend/assets/62726177/f33d9c95-de75-49b0-b6b0-dfcfaf032e4a" width="300px" /> |  <img src="https://github.com/tanselbay1/pokedex_frontend/assets/62726177/71806b34-fdb2-435d-a0bd-c6422abee57f" width="300px" /> |
